### PR TITLE
remove unary negation operator choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [X] `4`
 [X] `4.0`
 [ ] `'4'`
-[X] `-'4'`
+[X] `-4`
 
 ?: Which of the following is/are booleans?
 


### PR DESCRIPTION
This is really testing students' knowledge of JS operators — not JS data types. Maybe add something about unary operators to [the JavaScript Math lesson](https://github.com/learn-co-curriculum/intro-to-math.js)?

E.g., https://github.com/learn-co-curriculum/javascript-data-types-quiz/issues/10, and a few complaints via Ask a Question

cc: @aturkewi 